### PR TITLE
Fix playback crash on song selection

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -5,6 +5,8 @@
     <uses-permission android:name="android.permission.READ_MEDIA_AUDIO" />
     <!-- Required on API 28+ to start a foreground service -->
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <!-- Needed when using foregroundServiceType=mediaPlayback -->
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
     <application

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,6 +3,8 @@
 
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.READ_MEDIA_AUDIO" />
+    <!-- Required on API 28+ to start a foreground service -->
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
     <application

--- a/app/src/main/java/com/example/dsmusic/model/Song.kt
+++ b/app/src/main/java/com/example/dsmusic/model/Song.kt
@@ -3,5 +3,5 @@ package com.example.dsmusic.model
 data class Song(
     val title: String,
     val artist: String,
-    val path: String
+    val uri: String
 )

--- a/app/src/main/java/com/example/dsmusic/service/MusicService.kt
+++ b/app/src/main/java/com/example/dsmusic/service/MusicService.kt
@@ -16,6 +16,7 @@ import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
 import android.media.MediaPlayer
 import com.example.dsmusic.R
+import android.net.Uri
 
 class MusicService : Service() {
 
@@ -148,7 +149,7 @@ class MusicService : Service() {
     private fun playSong(song: Song) {
         mediaPlayer?.release()
         mediaPlayer = MediaPlayer().apply {
-            setDataSource(song.path)
+            setDataSource(this@MusicService, Uri.parse(song.uri))
             prepare()
             start()
 

--- a/app/src/main/java/com/example/dsmusic/utils/MusicScanner.kt
+++ b/app/src/main/java/com/example/dsmusic/utils/MusicScanner.kt
@@ -1,6 +1,7 @@
 package com.example.dsmusic.utils
 
 import android.content.Context
+import android.content.ContentUris
 import android.provider.MediaStore
 import com.example.dsmusic.model.Song
 
@@ -13,9 +14,9 @@ object MusicScanner {
 
         val collection = MediaStore.Audio.Media.EXTERNAL_CONTENT_URI
         val projection = arrayOf(
+            MediaStore.Audio.Media._ID,
             MediaStore.Audio.Media.TITLE,
-            MediaStore.Audio.Media.ARTIST,
-            MediaStore.Audio.Media.DATA
+            MediaStore.Audio.Media.ARTIST
         )
         val selection = "${MediaStore.Audio.Media.IS_MUSIC} != 0"
 
@@ -26,14 +27,15 @@ object MusicScanner {
             null,
             null
         )?.use { cursor ->
+            val idColumn = cursor.getColumnIndexOrThrow(MediaStore.Audio.Media._ID)
             val titleColumn = cursor.getColumnIndexOrThrow(MediaStore.Audio.Media.TITLE)
             val artistColumn = cursor.getColumnIndexOrThrow(MediaStore.Audio.Media.ARTIST)
-            val pathColumn = cursor.getColumnIndexOrThrow(MediaStore.Audio.Media.DATA)
             while (cursor.moveToNext()) {
+                val id = cursor.getLong(idColumn)
                 val title = cursor.getString(titleColumn)
                 val artist = cursor.getString(artistColumn)
-                val path = cursor.getString(pathColumn)
-                songs.add(Song(title, artist, path))
+                val uri = ContentUris.withAppendedId(MediaStore.Audio.Media.EXTERNAL_CONTENT_URI, id)
+                songs.add(Song(title, artist, uri.toString()))
             }
         }
         return songs


### PR DESCRIPTION
## Summary
- use a `uri` field for songs
- query MediaStore using `_ID` to build content URIs
- play media from content URI instead of direct file path

## Testing
- `gradle build` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ce498b99c83218b585e18d1690421