### PR TITLE
Add shuffle and repeat controls

### DIFF
--- a/app/src/main/java/com/example/dsmusic/service/MusicService.kt
+++ b/app/src/main/java/com/example/dsmusic/service/MusicService.kt
@@ -104,6 +104,10 @@ class MusicService : Service() {
         repeatMode = (repeatMode + 1) % 3
     }
 
+    fun isShuffle(): Boolean = isShuffling
+
+    fun getRepeatMode(): Int = repeatMode
+
     private fun togglePlay() {
         mediaPlayer?.let {
             if (it.isPlaying) {


### PR DESCRIPTION
## Summary
- add shuffle/repeat status getters
- show shuffle and repeat controls in MiniPlayer

## Testing
- `./gradlew assembleDebug` *(fails: Unable to access jarfile)*

------
https://chatgpt.com/codex/tasks/task_e_686d0af215408321b77e608ba9a5ae4e