### PR TITLE
Fix search keyboard action

### DIFF
--- a/app/src/main/java/com/example/dsmusic/MainActivity.kt
+++ b/app/src/main/java/com/example/dsmusic/MainActivity.kt
@@ -51,8 +51,8 @@ import com.example.dsmusic.utils.MusicScanner
 import com.google.gson.Gson
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.text.input.ImeAction
-import androidx.compose.ui.text.input.KeyboardActions
-import androidx.compose.ui.text.input.KeyboardOptions
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/app/src/main/java/com/example/dsmusic/MainActivity.kt
+++ b/app/src/main/java/com/example/dsmusic/MainActivity.kt
@@ -37,6 +37,7 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.core.content.ContextCompat
@@ -49,6 +50,9 @@ import com.example.dsmusic.ui.theme.TextWhite
 import com.example.dsmusic.utils.MusicScanner
 import com.google.gson.Gson
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardActions
+import androidx.compose.ui.text.input.KeyboardOptions
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -238,15 +242,21 @@ fun SearchScreen(
     currentSong: Song?
 ) {
     var query by remember { mutableStateOf("") }
+    val focusManager = LocalFocusManager.current
     val filtered = allSongs.filter { it.title.contains(query, true) || it.artist.contains(query, true) }
     Column(modifier = Modifier.fillMaxSize()) {
         TextField(
             value = query,
             onValueChange = { query = it },
-            modifier = Modifier.fillMaxSize(),
-            placeholder = { Text("Rechercher") }
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(8.dp),
+            placeholder = { Text("Rechercher") },
+            singleLine = true,
+            keyboardOptions = KeyboardOptions.Default.copy(imeAction = ImeAction.Search),
+            keyboardActions = KeyboardActions(onSearch = { focusManager.clearFocus() })
         )
-        LazyColumn {
+        LazyColumn(modifier = Modifier.weight(1f)) {
             itemsIndexed(filtered) { index, song ->
                 SongItem(
                     song = song,


### PR DESCRIPTION
## Summary
- ensure the search field uses the `Search` IME action
- close the keyboard on Search key press
- add needed imports for IME actions

## Testing
- `gradle wrapper --gradle-version 8.7` *(fails: Calculating task graph, then we cancelled)*
- `gradle tasks --all` *(fails: Calculating task graph)*

------
https://chatgpt.com/codex/tasks/task_e_686d0deda5c083219a4b0bfe53c85fc4