### PR TITLE
Fix playback startup from home screen

### DIFF
--- a/app/src/main/java/com/example/dsmusic/MainActivity.kt
+++ b/app/src/main/java/com/example/dsmusic/MainActivity.kt
@@ -497,19 +497,19 @@ fun SongItem(song: Song, onClick: () -> Unit, isCurrent: Boolean) {
 }
 
 fun startPlayback(context: android.content.Context, songs: List<Song>, index: Int) {
-    val intent = Intent(context, MusicService::class.java).apply {
+    val intent = Intent(context.applicationContext, MusicService::class.java).apply {
         action = MusicService.ACTION_START
         putExtra("SONGS", Gson().toJson(songs))
         putExtra("INDEX", index)
     }
-    ContextCompat.startForegroundService(context, intent)
+    ContextCompat.startForegroundService(context.applicationContext, intent)
 }
 
 fun togglePlayback(context: android.content.Context) {
-    val intent = Intent(context, MusicService::class.java).apply {
+    val intent = Intent(context.applicationContext, MusicService::class.java).apply {
         action = MusicService.ACTION_TOGGLE_PLAY
     }
-    ContextCompat.startForegroundService(context, intent)
+    ContextCompat.startForegroundService(context.applicationContext, intent)
 }
 
 @Composable


### PR DESCRIPTION
## Summary
- ensure music playback uses application context when starting the service

## Testing
- `./gradlew test --no-daemon` *(fails: no main manifest attribute in gradle-wrapper.jar)*

------
https://chatgpt.com/codex/tasks/task_e_686e322f03cc8321a0afe0249f86cdbe