### PR TITLE
Fix permission handling for Android 13

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,31 +63,32 @@
 
 ## Setup
 1. Mode développeur sur téléphone : activer le débogage USB et désactiver le blocage automatique.
-2. Utiliser `gradle` version 8.7 :
+2. Au premier lancement, accepter les permissions d'accès aux fichiers audio et d'affichage des notifications (Android 13+).
+3. Utiliser `gradle` version 8.7 :
    ```bash
    & "<path-to-gradle>"/gradle.bat wrapper --gradle-version 8.7
    ```
-3. Construire le projet :
+4. Construire le projet :
    ```bash
    ./gradlew clean build
    ```
-4. Lancer l’application sur l’appareil :
+5. Lancer l’application sur l’appareil :
    ```bash
    & "<path-to-adb>"/adb shell am start -n com.example.dsmusic/.MainActivity
    ```
-5. Vérifier les appareils connectés puis installer l’APK :
+6. Vérifier les appareils connectés puis installer l’APK :
    ```bash
    & "<path-to-adb>"/adb devices
    ./gradlew installDebug
    ```
-6. En cas de problème de connexion USB :
+7. En cas de problème de connexion USB :
    ```bash
    & "<path-to-adb>"/adb kill-server
    & "<path-to-adb>"/adb start-server
    & "<path-to-adb>"/adb devices
    ./gradlew installDebug
    ```
-6. Tester une branche du projet
+8. Tester une branche du projet
     ```bash
     git fetch origin <branch-name>
     git switch <branch-name>

--- a/app/src/main/java/com/example/dsmusic/MainActivity.kt
+++ b/app/src/main/java/com/example/dsmusic/MainActivity.kt
@@ -73,9 +73,16 @@ class MainActivity : ComponentActivity() {
 
     private fun requestAudioPermission() {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            val permissions = mutableListOf<String>()
             if (PermissionChecker.checkSelfPermission(this, Manifest.permission.READ_MEDIA_AUDIO) != PermissionChecker.PERMISSION_GRANTED) {
-                registerForActivityResult(ActivityResultContracts.RequestPermission()) {}
-                    .launch(Manifest.permission.READ_MEDIA_AUDIO)
+                permissions.add(Manifest.permission.READ_MEDIA_AUDIO)
+            }
+            if (PermissionChecker.checkSelfPermission(this, Manifest.permission.POST_NOTIFICATIONS) != PermissionChecker.PERMISSION_GRANTED) {
+                permissions.add(Manifest.permission.POST_NOTIFICATIONS)
+            }
+            if (permissions.isNotEmpty()) {
+                registerForActivityResult(ActivityResultContracts.RequestMultiplePermissions()) {}
+                    .launch(permissions.toTypedArray())
             }
         } else {
             if (PermissionChecker.checkSelfPermission(this, Manifest.permission.READ_EXTERNAL_STORAGE) != PermissionChecker.PERMISSION_GRANTED) {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
## Summary
- request POST_NOTIFICATIONS permission on Android 13+
- document the permission in the setup instructions
- update gradle wrapper for gradle 8.7

## Testing
- `gradle wrapper --gradle-version 8.7 --no-daemon --warning-mode all`
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e3b918d7c8321a81db4d808fec1c8