### PR TITLE
Fix playback initialization across menus

### DIFF
--- a/app/src/main/java/com/example/dsmusic/MainActivity.kt
+++ b/app/src/main/java/com/example/dsmusic/MainActivity.kt
@@ -54,6 +54,7 @@ import com.example.dsmusic.ui.theme.DSMusicTheme
 import com.example.dsmusic.ui.theme.PinkAccent
 import com.example.dsmusic.ui.theme.TextWhite
 import com.example.dsmusic.utils.MusicScanner
+import com.example.dsmusic.utils.PlaybackHolder
 import com.google.gson.Gson
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.text.input.ImeAction
@@ -497,9 +498,9 @@ fun SongItem(song: Song, onClick: () -> Unit, isCurrent: Boolean) {
 }
 
 fun startPlayback(context: android.content.Context, songs: List<Song>, index: Int) {
+    PlaybackHolder.songs = songs
     val intent = Intent(context, MusicService::class.java).apply {
         action = MusicService.ACTION_START
-        putExtra("SONGS", Gson().toJson(songs))
         putExtra("INDEX", index)
     }
     ContextCompat.startForegroundService(context, intent)

--- a/app/src/main/java/com/example/dsmusic/service/MusicService.kt
+++ b/app/src/main/java/com/example/dsmusic/service/MusicService.kt
@@ -17,6 +17,7 @@ import com.google.gson.reflect.TypeToken
 import android.media.MediaPlayer
 import com.example.dsmusic.R
 import android.net.Uri
+import com.example.dsmusic.utils.PlaybackHolder
 
 class MusicService : Service() {
 
@@ -63,10 +64,18 @@ class MusicService : Service() {
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         when (intent?.action) {
             ACTION_START -> {
-                val songsJson = intent.getStringExtra("SONGS") ?: return START_NOT_STICKY
-                songs = Gson().fromJson(songsJson, object : TypeToken<MutableList<Song>>() {}.type)
-                currentIndex = intent.getIntExtra("INDEX", 0)
-                playSong(songs[currentIndex])
+                val passed = PlaybackHolder.songs
+                if (passed.isNotEmpty()) {
+                    songs = passed.toMutableList()
+                    currentIndex = intent.getIntExtra("INDEX", 0)
+                    playSong(songs[currentIndex])
+                    PlaybackHolder.songs = emptyList()
+                } else {
+                    val songsJson = intent.getStringExtra("SONGS") ?: return START_NOT_STICKY
+                    songs = Gson().fromJson(songsJson, object : TypeToken<MutableList<Song>>() {}.type)
+                    currentIndex = intent.getIntExtra("INDEX", 0)
+                    playSong(songs[currentIndex])
+                }
             }
             ACTION_TOGGLE_PLAY -> togglePlay()
             ACTION_NEXT -> nextSong()

--- a/app/src/main/java/com/example/dsmusic/utils/PlaybackHolder.kt
+++ b/app/src/main/java/com/example/dsmusic/utils/PlaybackHolder.kt
@@ -1,0 +1,7 @@
+package com.example.dsmusic.utils
+
+import com.example.dsmusic.model.Song
+
+object PlaybackHolder {
+    var songs: List<Song> = emptyList()
+}


### PR DESCRIPTION
## Summary
- store playlist data in `PlaybackHolder` object
- read playlist from `PlaybackHolder` inside `MusicService`
- update `startPlayback` to use `PlaybackHolder`

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to access jarfile)*

------
https://chatgpt.com/codex/tasks/task_e_686f7a561ac083218463cdc237ac1adb