### PR TITLE
Fix crash when skipping tracks

### DIFF
--- a/app/src/main/java/com/example/dsmusic/service/MusicService.kt
+++ b/app/src/main/java/com/example/dsmusic/service/MusicService.kt
@@ -131,11 +131,17 @@ class MusicService : Service() {
     }
 
     fun nextSong() {
+        if (songs.isEmpty()) return
+
         mediaPlayer?.stop()
         mediaPlayer?.release()
 
         currentIndex = if (isShuffling) {
-            (songs.indices - currentIndex).random()
+            if (songs.size > 1) {
+                (songs.indices - currentIndex).random()
+            } else {
+                currentIndex
+            }
         } else {
             (currentIndex + 1) % songs.size
         }
@@ -148,12 +154,18 @@ class MusicService : Service() {
     }
 
     fun previousSong() {
+        if (songs.isEmpty()) return
+
         mediaPlayer?.stop()
         mediaPlayer?.release()
 
         val atFirst = currentIndex == 0
         currentIndex = if (isShuffling) {
-            (songs.indices - currentIndex).random()
+            if (songs.size > 1) {
+                (songs.indices - currentIndex).random()
+            } else {
+                currentIndex
+            }
         } else {
             if (currentIndex - 1 < 0) songs.size - 1 else currentIndex - 1
         }


### PR DESCRIPTION
## Summary
- handle edge cases when skipping tracks with shuffle
- avoid crashes if playlist only has one song

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f7fba17e883219c6b24006275f29c