### PR TITLE
Apply accent color per background theme

### DIFF
--- a/app/src/main/java/com/example/dsmusic/MainActivity.kt
+++ b/app/src/main/java/com/example/dsmusic/MainActivity.kt
@@ -57,7 +57,7 @@ import androidx.core.content.PermissionChecker
 import com.example.dsmusic.model.Song
 import com.example.dsmusic.service.MusicService
 import com.example.dsmusic.ui.theme.DSMusicTheme
-import com.example.dsmusic.ui.theme.PinkAccent
+import com.example.dsmusic.ui.theme.AccentColorDefault
 import com.example.dsmusic.ui.theme.TextWhite
 import com.example.dsmusic.utils.MusicScanner
 import com.example.dsmusic.utils.PlaybackHolder
@@ -72,9 +72,7 @@ class MainActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
         requestAudioPermission()
         setContent {
-            DSMusicTheme {
-                MusicApp()
-            }
+            MusicApp()
         }
     }
 
@@ -113,6 +111,12 @@ fun MusicApp() {
         3 -> R.drawable.back_3
         else -> R.drawable.back_4
     }
+    val accentColor = when (selectedTheme) {
+        1 -> AccentColorDefault
+        2 -> Color(0xFF03DAC5)
+        3 -> Color(0xFFFF5722)
+        else -> Color(0xFF4CAF50)
+    }
     val connection = remember {
         object : ServiceConnection {
             override fun onServiceConnected(name: ComponentName?, binder: IBinder?) {
@@ -150,7 +154,8 @@ fun MusicApp() {
         }
     }
 
-    Box(modifier = Modifier.fillMaxSize()) {
+    DSMusicTheme(accentColor = accentColor) {
+        Box(modifier = Modifier.fillMaxSize()) {
         Image(
             painter = painterResource(backgroundRes),
             contentDescription = null,
@@ -615,7 +620,7 @@ fun ArtistItem(artist: String, onClick: () -> Unit) {
 @Composable
 fun SongItem(song: Song, onClick: () -> Unit, isCurrent: Boolean) {
     val colors = ListItemDefaults.colors(
-        containerColor = if (isCurrent) PinkAccent else Color.Transparent,
+        containerColor = if (isCurrent) MaterialTheme.colorScheme.primary else Color.Transparent,
         headlineColor = if (isCurrent) TextWhite else MaterialTheme.colorScheme.onSurface,
         supportingColor = if (isCurrent) TextWhite else MaterialTheme.colorScheme.onSurfaceVariant
     )
@@ -688,7 +693,7 @@ fun MiniPlayer(
                     Text(song.artist, style = MaterialTheme.typography.bodySmall)
                 }
                 IconButton(onClick = onShuffle) {
-                    val tint = if (shuffleOn) PinkAccent else MaterialTheme.colorScheme.onSurface
+                    val tint = if (shuffleOn) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurface
                     Icon(Icons.Filled.Shuffle, contentDescription = "Shuffle", tint = tint)
                 }
                 IconButton(onClick = onPrevious) {
@@ -707,7 +712,7 @@ fun MiniPlayer(
                         1 -> Icons.Filled.RepeatOne
                         else -> Icons.Filled.Repeat
                     }
-                    val tint = if (repeatMode == 0) MaterialTheme.colorScheme.onSurface else PinkAccent
+                    val tint = if (repeatMode == 0) MaterialTheme.colorScheme.onSurface else MaterialTheme.colorScheme.primary
                     Icon(icon, contentDescription = "Repeat", tint = tint)
                 }
             }

--- a/app/src/main/java/com/example/dsmusic/ui/theme/Color.kt
+++ b/app/src/main/java/com/example/dsmusic/ui/theme/Color.kt
@@ -2,6 +2,7 @@ package com.example.dsmusic.ui.theme
 
 import androidx.compose.ui.graphics.Color
 
-val PinkAccent = Color(0xFFFF007A)
+/** Default accent color used when no theme-specific accent is selected. */
+val AccentColorDefault = Color(0xFF6200EE)
 val BackgroundBlack = Color(0xFF000000)
 val TextWhite = Color(0xFFFFFFFF)

--- a/app/src/main/java/com/example/dsmusic/ui/theme/Theme.kt
+++ b/app/src/main/java/com/example/dsmusic/ui/theme/Theme.kt
@@ -1,25 +1,27 @@
 package com.example.dsmusic.ui.theme
 
-import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.darkColorScheme
 import androidx.compose.runtime.Composable
-
-private val ColorScheme = darkColorScheme(
-    primary = PinkAccent,
-    secondary = PinkAccent,
-    background = BackgroundBlack,
-    surface = BackgroundBlack,
-    onPrimary = TextWhite,
-    onSecondary = TextWhite,
-    onBackground = TextWhite,
-    onSurface = TextWhite
-)
+import androidx.compose.ui.graphics.Color
 
 @Composable
-fun DSMusicTheme(content: @Composable () -> Unit) {
+fun DSMusicTheme(
+    accentColor: Color = AccentColorDefault,
+    content: @Composable () -> Unit
+) {
+    val colorScheme = darkColorScheme(
+        primary = accentColor,
+        secondary = accentColor,
+        background = BackgroundBlack,
+        surface = BackgroundBlack,
+        onPrimary = TextWhite,
+        onSecondary = TextWhite,
+        onBackground = TextWhite,
+        onSurface = TextWhite
+    )
     MaterialTheme(
-        colorScheme = ColorScheme,
+        colorScheme = colorScheme,
         typography = MaterialTheme.typography,
         content = content
     )

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <color name="accent_pink">#FF007A</color>
+    <color name="accent_color">#6200EE</color>
     <color name="background_black">#000000</color>
     <color name="white">#FFFFFF</color>
 </resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,7 +1,7 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
     <style name="AppTheme" parent="Theme.Material3.Dark.NoActionBar">
-        <item name="colorPrimary">@color/accent_pink</item>
-        <item name="colorSecondary">@color/accent_pink</item>
+        <item name="colorPrimary">@color/accent_color</item>
+        <item name="colorSecondary">@color/accent_color</item>
         <item name="android:colorBackground">@color/background_black</item>
         <item name="colorOnPrimary">@color/white</item>
     </style>


### PR DESCRIPTION
## Summary
- rename accent color resources to be theme-agnostic
- allow `DSMusicTheme` to accept a dynamic accent color
- compute accent color for each background theme in `MusicApp`
- use `MaterialTheme.colorScheme.primary` instead of hardcoded pink

## Testing
- `./gradlew test --no-daemon` *(fails: unable to access gradle-wrapper.jar)*

------
https://chatgpt.com/codex/tasks/task_e_6871159abbd8832189eef68fee5992f4