### PR TITLE
Add blur and opacity to background image

### DIFF
--- a/app/src/main/java/com/example/dsmusic/MainActivity.kt
+++ b/app/src/main/java/com/example/dsmusic/MainActivity.kt
@@ -52,6 +52,8 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.draw.blur
 import androidx.core.content.ContextCompat
 import androidx.core.content.PermissionChecker
 import com.example.dsmusic.model.Song
@@ -159,7 +161,10 @@ fun MusicApp() {
             painter = painterResource(backgroundRes),
             contentDescription = null,
             contentScale = ContentScale.Crop,
-            modifier = Modifier.fillMaxSize()
+            modifier = Modifier
+                .fillMaxSize()
+                .blur(8.dp)
+                .alpha(0.7f)
         )
 
         Scaffold(


### PR DESCRIPTION
## Summary
- make app background images semi-transparent
- add blur to background images

## Testing
- `./gradlew test` *(fails: Unable to access jarfile gradle-wrapper.jar)*

------
https://chatgpt.com/codex/tasks/task_e_687146bf17cc8321a9950af5eac2928e