### PR TITLE
Persist selected theme

### DIFF
--- a/app/src/main/java/com/example/dsmusic/MainActivity.kt
+++ b/app/src/main/java/com/example/dsmusic/MainActivity.kt
@@ -62,6 +62,7 @@ import com.example.dsmusic.ui.theme.DSMusicTheme
 import com.example.dsmusic.ui.theme.TextBlack
 import com.example.dsmusic.utils.MusicScanner
 import com.example.dsmusic.utils.PlaybackHolder
+import com.example.dsmusic.utils.ThemePreference
 import com.google.gson.Gson
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.text.input.ImeAction
@@ -110,7 +111,7 @@ fun MusicApp() {
     var shuffleOn by remember { mutableStateOf(false) }
     var repeatMode by remember { mutableStateOf(0) }
     var musicService by remember { mutableStateOf<MusicService?>(null) }
-    var selectedTheme by rememberSaveable { mutableStateOf(1) }
+    var selectedTheme by rememberSaveable { mutableStateOf(ThemePreference.loadTheme(context)) }
     val backgroundRes = when (selectedTheme) {
         1 -> R.drawable.back_1
         2 -> R.drawable.back_2
@@ -199,7 +200,10 @@ fun MusicApp() {
                         currentIndex = index
                         currentSong = song
                         isPlaying = true
-                    }, currentSong = currentSong, showFilter = true, onThemeSelected = { selectedTheme = it })
+                    }, currentSong = currentSong, showFilter = true, onThemeSelected = { theme ->
+                        selectedTheme = theme
+                        ThemePreference.saveTheme(context, theme)
+                    })
                     BottomScreen.Search -> SearchScreen(songs, onSongClick = { song, index, list ->
                         startPlayback(context, list, index)
                         playlist = list
@@ -213,7 +217,10 @@ fun MusicApp() {
                         currentIndex = index
                         currentSong = song
                         isPlaying = true
-                    }, currentSong = currentSong, onThemeSelected = { selectedTheme = it })
+                    }, currentSong = currentSong, onThemeSelected = { theme ->
+                        selectedTheme = theme
+                        ThemePreference.saveTheme(context, theme)
+                    })
                 }
             }
             currentSong?.let { song ->

--- a/app/src/main/java/com/example/dsmusic/utils/ThemePreference.kt
+++ b/app/src/main/java/com/example/dsmusic/utils/ThemePreference.kt
@@ -1,0 +1,27 @@
+package com.example.dsmusic.utils
+
+import android.content.Context
+
+/**
+ * Helper object to persist the selected theme using [android.content.SharedPreferences].
+ */
+object ThemePreference {
+    private const val PREF_NAME = "user_prefs"
+    private const val KEY_THEME = "selected_theme"
+
+    /**
+     * Save the chosen theme index.
+     */
+    fun saveTheme(context: Context, theme: Int) {
+        val prefs = context.getSharedPreferences(PREF_NAME, Context.MODE_PRIVATE)
+        prefs.edit().putInt(KEY_THEME, theme).apply()
+    }
+
+    /**
+     * Retrieve the last selected theme. Defaults to `1` if none was stored.
+     */
+    fun loadTheme(context: Context): Int {
+        val prefs = context.getSharedPreferences(PREF_NAME, Context.MODE_PRIVATE)
+        return prefs.getInt(KEY_THEME, 1)
+    }
+}


### PR DESCRIPTION
## Summary
- keep selected theme across app launches with `ThemePreference`
- load stored theme when showing UI

## Testing
- `gradle clean build` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6876235eeb148321a000719ec110dee7