### PR TITLE
Add dependency links

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,11 @@ dsmusic est un lecteur audio Android écrit en Kotlin. L'application se concentr
 - MediaStore API pour l'indexation des fichiers
 - Jetpack Compose et Material3 pour l'interface
 
+## Dépendances
+- [Android Studio](https://developer.android.com/studio) pour éditer et construire le projet
+- [ADB](https://developer.android.com/tools/adb) pour interagir avec l'appareil
+- [Gradle](https://gradle.org/) pour le système de build
+
 ## Structure du projet
 ```bash
 /musicplayer


### PR DESCRIPTION
## Summary
- add a `Dépendances` section listing Android Studio, ADB and Gradle with links

## Testing
- `./gradlew clean build` *(fails: gradle-wrapper.jar missing)*

------
https://chatgpt.com/codex/tasks/task_e_688291836648832199dab8697ce05ee0